### PR TITLE
Fix Wompi sandbox API URL

### DIFF
--- a/mimeiapify/wompi/wompi_async.py
+++ b/mimeiapify/wompi/wompi_async.py
@@ -25,7 +25,8 @@ class WompiAsync:
         self.integrity_key = integrity_key
         self.environment = environment
         self.base_url = "https://checkout.wompi.co/p/"
-        self.api_url = f"https://{'sandbox.' if environment == 'sandbox' else ''}production.wompi.co/v1"
+        env_subdomain = "sandbox" if environment == "sandbox" else "production"
+        self.api_url = f"https://{env_subdomain}.wompi.co/v1"
         self._session = session
         self._own_session = False
     

--- a/test_serde.py
+++ b/test_serde.py
@@ -1,4 +1,4 @@
-from symphony_ai.redis.redis_handler.serde import dumps, loads
+from mimeiapify.symphony_ai.redis.redis_handler.serde import dumps, loads
 from pydantic import BaseModel
 
 class User(BaseModel):


### PR DESCRIPTION
## Summary
- fix wrong sandbox API url for WompiAsync
- update serde test imports

## Testing
- `python test_serde.py`

------
https://chatgpt.com/codex/tasks/task_e_6840eb2ac6f08330960071aa8a108c77