### PR TITLE
Add shared state context utilities

### DIFF
--- a/mimeiapify/symphony_ai/redis/redis_handler/__init__.py
+++ b/mimeiapify/symphony_ai/redis/redis_handler/__init__.py
@@ -4,7 +4,7 @@ Redis Handler Package - Refactored from God Class
 This package refactors the monolithic RedisHandler class following SOLID principles:
 
 Single Responsibility:
-- UserRepo: User data management
+- RedisUser: User data management
 - HandlerRepo: Handler state management  
 - TableRepo: Table/DataFrame operations
 - TriggerRepo: Expiration trigger management
@@ -19,9 +19,9 @@ Each repository inherits from TenantCache which provides:
 - Serialization via serde module
 
 Usage:
-    from symphony_ai.redis.redis_handler import UserRepo, HandlerRepo, SharedStateRepo
+    from symphony_ai.redis.redis_handler import RedisUser, HandlerRepo, SharedStateRepo
     
-    users = UserRepo(tenant="my_tenant", ttl_default=3600)
+    users = RedisUser(tenant="my_tenant", ttl_default=3600)
     await users.upsert("user123", {"name": "Alice", "score": 100})
     
     handlers = HandlerRepo(tenant="my_tenant") 
@@ -31,7 +31,7 @@ Usage:
     await shared_state.set("conversation", {"step": 1, "context": {...}})
 """
 
-from .user_repo import UserRepo
+from .redis_user import RedisUser
 from .handler_repo import HandlerRepo
 from .table_repo import TableRepo
 from .trigger_repo import TriggerRepo
@@ -43,7 +43,7 @@ from .key_factory import KeyFactory
 from . import serde
 
 __all__ = [
-    "UserRepo",
+    "RedisUser",
     "HandlerRepo", 
     "TableRepo",
     "TriggerRepo",

--- a/mimeiapify/symphony_ai/redis/redis_handler/generic_repo.py
+++ b/mimeiapify/symphony_ai/redis/redis_handler/generic_repo.py
@@ -23,7 +23,7 @@ class GenericRepo(TenantCache):
     - get_ttl_generic() -> get_ttl() [inherited from TenantCache]
     
     Single Responsibility: Generic key-value operations with tenant context
-    Note: Prefer specific repositories (UserRepo, HandlerRepo, etc.) over this generic one
+    Note: Prefer specific repositories (RedisUser, HandlerRepo, etc.) over this generic one
     """
     
     def _key(self, key_base: str) -> str:

--- a/mimeiapify/symphony_ai/redis/redis_handler/redis_user.py
+++ b/mimeiapify/symphony_ai/redis/redis_handler/redis_user.py
@@ -7,10 +7,10 @@ from .tenant_cache import TenantCache
 from ..ops import hset_with_expire, hincrby_with_expire, hdel
 from .serde import dumps
 
-logger = logging.getLogger("UserRepo")
+logger = logging.getLogger("RedisUser")
 
 
-class UserRepo(TenantCache):
+class RedisUser(TenantCache):
     """
     Repository for user-specific operations.
     

--- a/mimeiapify/symphony_ai/symphony_concurrency/globals.py
+++ b/mimeiapify/symphony_ai/symphony_concurrency/globals.py
@@ -45,7 +45,7 @@ class GlobalSymphony:
         limiter (anyio.CapacityLimiter): Concurrency limiter.
         redis (Optional[Redis]): Optional Redis connection.
     """
-    _instance: ClassVar["GlobalSymphony"] | None = None
+    _instance: ClassVar[Optional["GlobalSymphony"]] = None
 
     # ---- runtime attributes ----
     loop:            asyncio.AbstractEventLoop

--- a/mimeiapify/symphony_ai/symphony_concurrency/redis/__init__.py
+++ b/mimeiapify/symphony_ai/symphony_concurrency/redis/__init__.py
@@ -1,0 +1,5 @@
+"""Redis helpers for symphony_concurrency."""
+
+from .context import _current_ss, SharedStateRepo
+
+__all__ = ["SharedStateRepo", "_current_ss"]

--- a/mimeiapify/symphony_ai/symphony_concurrency/redis/context.py
+++ b/mimeiapify/symphony_ai/symphony_concurrency/redis/context.py
@@ -1,0 +1,8 @@
+"""Context variable holding the current request's :class:`SharedStateRepo`."""
+
+from contextvars import ContextVar
+from ...redis.redis_handler.shared_state_repo import SharedStateRepo
+
+_current_ss: ContextVar[SharedStateRepo] = ContextVar("current_shared_state")
+
+__all__ = ["_current_ss", "SharedStateRepo"]


### PR DESCRIPTION
## Summary
- replace exported wrapper with direct import of `SharedStateRepo`
- use `_current_ss` ContextVar from the new import path
- rename `UserRepo` class to `RedisUser`
- update docs for ContextVar usage and class rename

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841193ac2388330b8964f353b270029