### PR TITLE
Fix logger docs and add utils README

### DIFF
--- a/mimeiapify/utils/README.md
+++ b/mimeiapify/utils/README.md
@@ -1,0 +1,48 @@
+# Utils Module
+
+This folder contains helper utilities used across the `mimeiapify` package.
+
+## Logger
+
+`logger.py` exposes `setup_logging`, an opinionated configuration based on
+[Rich](https://github.com/Textualize/rich). Call this function once when your
+application starts to initialise console logging and, optionally, daily log
+files.
+
+```python
+from mimeiapify.utils.logger import setup_logging
+
+# console only
+setup_logging(level="DEBUG")
+
+# console plus daily file
+setup_logging(
+    level="INFO",
+    mode="DEV",          # enables file logging
+    log_dir="./logs",    # folder for log files
+)
+```
+
+Use the `console_fmt` and `file_fmt` parameters to customise the output format
+and add contextual information (tenant IDs, request IDs, etc.).
+
+## Helper Functions
+
+`helper_functions.py` bundles small utilities that are useful across projects:
+
+- `parse_datetime_to_target_tz` – parse a datetime or ISO string and convert it
+  to a given timezone.
+- `datetime_to_iso_string` – serialise aware datetimes to an ISO string.
+- `format_date_friendly` – convert an ISO date string to a human friendly
+  Spanish representation.
+- `robust_clean_text` – clean and normalise blocks of text (dedent, collapse
+  whitespace, remove markdown headings, etc.).
+
+Example usage:
+
+```python
+from mimeiapify.utils import helper_functions as hf
+
+parsed = hf.parse_datetime_to_target_tz("2025-01-16T15:04:09Z", "America/Bogota")
+clean = hf.robust_clean_text("## Heading\nSome **bold** text")
+```

--- a/mimeiapify/utils/logger.py
+++ b/mimeiapify/utils/logger.py
@@ -1,27 +1,28 @@
 """
-utils.logger
+mimeiapify.utils.logger
 
 Opinionated Rich-based logger for colour-rich, flexible logging in Python projects.
 
-Provides a setup_logging() function to configure console and file logging with rich formatting.
+`setup_logging()` configures console and optional file logging. Call it once when
+your application starts.
 
-Usage:
-    from mimeiapify.utils.logger import setup_logging
-    setup_logging(level="DEBUG", mode="DEV", log_dir="./logs")
+Example
+-------
+```python
+from mimeiapify.utils.logger import setup_logging
 
-Call once at application start-up (FastAPI lifespan or if __name__ == "__main__":).
+# console only
+setup_logging(level="DEBUG")
 
-Usage
------
-from symphony_concurrency.utils.logger import setup_logging
-
+# console + daily file
 setup_logging(
     level="INFO",
     mode="DEV",
     log_dir="./logs",
-    console_fmt="[%(levelname)s] %(name)s • %(message)s",
-    file_fmt="%(asctime)s — %(levelname)s — %(name)s — %(message)s",
+    console_fmt="[%(levelname)s] [%(name)s] %(message)s",
 )
+```
+Pass custom ``console_fmt`` or ``file_fmt`` to add request IDs, tenant info, etc.
 """
 
 from __future__ import annotations
@@ -119,7 +120,7 @@ def setup_logging(
 Opinionated Rich-based logger.
 
 ```python
-from symphony_concurrency.utils.logger import setup_logging
+from mimeiapify.utils.logger import setup_logging
 
 # console only
 setup_logging(level="DEBUG")


### PR DESCRIPTION
## Summary
- fix outdated usage examples in `logger.py`
- add new `README.md` for the utils package

## Testing
- `ruff check` *(fails: many existing lint errors)*
- `pytest -q` *(fails: async plugin missing in tests)*

------
https://chatgpt.com/codex/tasks/task_e_687d8a18d3a0833098252bdc87dc8add